### PR TITLE
Interactions rewrite

### DIFF
--- a/src/main/java/com/quattage/mechano/Mechano.java
+++ b/src/main/java/com/quattage/mechano/Mechano.java
@@ -82,7 +82,7 @@ public class Mechano {
     }
 
     public static void logSlow(String text) {
-        logSlow(text, 20);
+        logSlow(text, 500);
     }
 
     private static long lastLog = 0;

--- a/src/main/java/com/quattage/mechano/content/block/power/transfer/connector/transmission/StackedConnectorGenerator.java
+++ b/src/main/java/com/quattage/mechano/content/block/power/transfer/connector/transmission/StackedConnectorGenerator.java
@@ -3,8 +3,8 @@ package com.quattage.mechano.content.block.power.transfer.connector.transmission
 import com.quattage.mechano.Mechano;
 import com.quattage.mechano.content.block.power.transfer.connector.transmission.stacked.ConnectorStackedTier0Block;
 import com.quattage.mechano.core.block.DirectionTransformer;
+import com.quattage.mechano.core.block.RootUpgradableBlock;
 import com.quattage.mechano.core.block.datagen.DynamicStateGenerator;
-import com.quattage.mechano.core.block.upgradable.RootUpgradableBlock;
 import com.simibubi.create.foundation.data.SpecialBlockStateGen;
 import com.tterrag.registrate.providers.DataGenContext;
 import com.tterrag.registrate.providers.RegistrateBlockstateProvider;

--- a/src/main/java/com/quattage/mechano/content/block/power/transfer/connector/transmission/stacked/ConnectorStackedTier0Block.java
+++ b/src/main/java/com/quattage/mechano/content/block/power/transfer/connector/transmission/stacked/ConnectorStackedTier0Block.java
@@ -6,7 +6,7 @@ import com.quattage.mechano.MechanoBlockEntities;
 import com.quattage.mechano.MechanoBlocks;
 import com.quattage.mechano.core.CreativeTabExcludable;
 import com.quattage.mechano.core.block.CombinedOrientedBlock;
-import com.quattage.mechano.core.block.upgradable.RootUpgradableBlock;
+import com.quattage.mechano.core.block.RootUpgradableBlock;
 import com.quattage.mechano.core.util.ShapeBuilder;
 import com.simibubi.create.foundation.block.IBE;
 import com.simibubi.create.foundation.utility.VoxelShaper;

--- a/src/main/java/com/quattage/mechano/content/block/power/transfer/connector/transmission/stacked/ConnectorStackedTier1Block.java
+++ b/src/main/java/com/quattage/mechano/content/block/power/transfer/connector/transmission/stacked/ConnectorStackedTier1Block.java
@@ -6,7 +6,7 @@ import com.quattage.mechano.MechanoBlockEntities;
 import com.quattage.mechano.MechanoBlocks;
 import com.quattage.mechano.core.CreativeTabExcludable;
 import com.quattage.mechano.core.block.CombinedOrientedBlock;
-import com.quattage.mechano.core.block.upgradable.RootUpgradableBlock;
+import com.quattage.mechano.core.block.RootUpgradableBlock;
 import com.quattage.mechano.core.util.ShapeBuilder;
 import com.simibubi.create.foundation.block.IBE;
 import com.simibubi.create.foundation.utility.VoxelShaper;

--- a/src/main/java/com/quattage/mechano/content/block/power/transfer/connector/transmission/stacked/ConnectorStackedTier2Block.java
+++ b/src/main/java/com/quattage/mechano/content/block/power/transfer/connector/transmission/stacked/ConnectorStackedTier2Block.java
@@ -6,7 +6,7 @@ import com.quattage.mechano.MechanoBlockEntities;
 import com.quattage.mechano.MechanoBlocks;
 import com.quattage.mechano.core.CreativeTabExcludable;
 import com.quattage.mechano.core.block.CombinedOrientedBlock;
-import com.quattage.mechano.core.block.upgradable.RootUpgradableBlock;
+import com.quattage.mechano.core.block.RootUpgradableBlock;
 import com.quattage.mechano.core.util.ShapeBuilder;
 import com.simibubi.create.foundation.block.IBE;
 import com.simibubi.create.foundation.utility.VoxelShaper;

--- a/src/main/java/com/quattage/mechano/content/block/power/transfer/connector/transmission/stacked/ConnectorStackedTier3Block.java
+++ b/src/main/java/com/quattage/mechano/content/block/power/transfer/connector/transmission/stacked/ConnectorStackedTier3Block.java
@@ -7,7 +7,7 @@ import com.quattage.mechano.MechanoBlockEntities;
 import com.quattage.mechano.MechanoBlocks;
 import com.quattage.mechano.core.CreativeTabExcludable;
 import com.quattage.mechano.core.block.CombinedOrientedBlock;
-import com.quattage.mechano.core.block.upgradable.RootUpgradableBlock;
+import com.quattage.mechano.core.block.RootUpgradableBlock;
 import com.quattage.mechano.core.util.ShapeBuilder;
 import com.simibubi.create.foundation.block.IBE;
 import com.simibubi.create.foundation.utility.VoxelShaper;

--- a/src/main/java/com/quattage/mechano/core/block/RootUpgradableBlock.java
+++ b/src/main/java/com/quattage/mechano/core/block/RootUpgradableBlock.java
@@ -1,11 +1,9 @@
-package com.quattage.mechano.core.block.upgradable;
+package com.quattage.mechano.core.block;
 
 import java.util.ArrayList;
 
 import javax.annotation.Nullable;
 
-import com.quattage.mechano.core.block.CombinedOrientedBlock;
-import com.quattage.mechano.core.block.DirectionTransformer;
 import com.quattage.mechano.core.block.orientation.CombinedOrientation;
 import com.quattage.mechano.core.util.BlockMath;
 

--- a/src/main/java/com/quattage/mechano/core/electricity/block/NodeOrientable.java
+++ b/src/main/java/com/quattage/mechano/core/electricity/block/NodeOrientable.java
@@ -17,7 +17,7 @@ public interface NodeOrientable {
         if(!state.hasBlockEntity()) return;
         BlockEntity be = world.getBlockEntity(pos);
         if(be instanceof ElectricBlockEntity ebe) {
-            ebe.nodes.rotate(dir);
+            ebe.nodeBank.rotate(dir);
         }
     }
 }

--- a/src/main/java/com/quattage/mechano/core/electricity/blockEntity/ElectricBlockEntity.java
+++ b/src/main/java/com/quattage/mechano/core/electricity/blockEntity/ElectricBlockEntity.java
@@ -26,7 +26,7 @@ import net.minecraftforge.common.util.LazyOptional;
 
 public abstract class ElectricBlockEntity extends SmartBlockEntity {
 
-    public final NodeBank nodes;
+    public final NodeBank nodeBank;
 
     @Override
     public void addBehaviours(List<BlockEntityBehaviour> behaviours) {}
@@ -36,7 +36,7 @@ public abstract class ElectricBlockEntity extends SmartBlockEntity {
         setLazyTickRate(20);
         NodeBankBuilder init = new NodeBankBuilder().at(this);
         prepare(init);
-        nodes = init.build();
+        nodeBank = init.build();
     }
 
     /***
@@ -66,7 +66,7 @@ public abstract class ElectricBlockEntity extends SmartBlockEntity {
     @Override
     public <T> @NotNull LazyOptional<T> getCapability(@NotNull Capability<T> cap, @Nullable Direction side) {
         super.getCapability(cap, side);
-        return nodes.provideEnergyCapabilities(cap, side);
+        return nodeBank.provideEnergyCapabilities(cap, side);
     }
 
     /***
@@ -78,19 +78,19 @@ public abstract class ElectricBlockEntity extends SmartBlockEntity {
         Block caller = state.getBlock();
         if(state != null && caller != null) {
             if(caller instanceof DirectionalBlock db) {
-                nodes.rotate(state.getValue(DirectionalBlock.FACING));
+                nodeBank.rotate(state.getValue(DirectionalBlock.FACING));
             }
             else if(caller instanceof HorizontalDirectionalBlock hb) {
-                nodes.rotate(state.getValue(HorizontalDirectionalBlock.FACING));
+                nodeBank.rotate(state.getValue(HorizontalDirectionalBlock.FACING));
             }
             else if(caller instanceof CombinedOrientedBlock cb) {
-                nodes.rotate(state.getValue(CombinedOrientedBlock.ORIENTATION));
+                nodeBank.rotate(state.getValue(CombinedOrientedBlock.ORIENTATION));
             }
             else if (caller instanceof SimpleOrientedBlock sb) {
-                nodes.rotate(state.getValue(SimpleOrientedBlock.ORIENTATION));
+                nodeBank.rotate(state.getValue(SimpleOrientedBlock.ORIENTATION));
             }
             else if (caller instanceof VerticallyOrientedBlock vb) {
-                nodes.rotate(state.getValue(VerticallyOrientedBlock.ORIENTATION));
+                nodeBank.rotate(state.getValue(VerticallyOrientedBlock.ORIENTATION));
             }
         }
     }
@@ -98,14 +98,14 @@ public abstract class ElectricBlockEntity extends SmartBlockEntity {
     @Override
     public void remove() {
         if(!this.level.isClientSide)
-            nodes.destroy();
+            nodeBank.destroy();
         super.remove();
     }
 
     @Override
     public void initialize() {
         super.initialize();
-        nodes.init();
+        nodeBank.init();
         refreshOrient();
         this.level.sendBlockUpdated(this.worldPosition, this.getBlockState(), this.getBlockState(), 3);
     }
@@ -113,30 +113,30 @@ public abstract class ElectricBlockEntity extends SmartBlockEntity {
     @Override
     public void onLoad() {
         super.onLoad();
-        nodes.loadEnergy();
+        nodeBank.loadEnergy();
     }
 
     @Override
     public void invalidateCaps() {
         super.invalidateCaps();
-        nodes.invalidateEnergy();
+        nodeBank.invalidateEnergy();
     }
     
     @Override
     protected void write(CompoundTag tag, boolean clientPacket) {
         super.write(tag, clientPacket);
-        nodes.writeTo(tag);
+        nodeBank.writeTo(tag);
     }
 
     @Override
     protected void read(CompoundTag tag, boolean clientPacket) {
-        nodes.readFrom(tag);
+        nodeBank.readFrom(tag);
         super.read(tag, clientPacket);
     }
 
     @Override
     public void handleUpdateTag(CompoundTag tag) {
         super.handleUpdateTag(tag);
-        nodes.readFrom(tag);
+        nodeBank.readFrom(tag);
     }
 }

--- a/src/main/java/com/quattage/mechano/core/electricity/network/EnergySyncS2CPacket.java
+++ b/src/main/java/com/quattage/mechano/core/electricity/network/EnergySyncS2CPacket.java
@@ -35,7 +35,7 @@ public class EnergySyncS2CPacket implements Packetable {
         NetworkEvent.Context context = supplier.get();
         context.enqueueWork(() -> {
             if(Minecraft.getInstance().level.getBlockEntity(target) instanceof ElectricBlockEntity ebe) {
-                ebe.nodes.setEnergyStored(energy);
+                ebe.nodeBank.setEnergyStored(energy);
             }
         });
         return true;

--- a/src/main/java/com/quattage/mechano/core/electricity/node/base/ElectricNode.java
+++ b/src/main/java/com/quattage/mechano/core/electricity/node/base/ElectricNode.java
@@ -171,10 +171,39 @@ public class ElectricNode {
         return location.getHitSize();
     }
 
+    /***
+     * 
+     * @param checkConnection Connection to check against
+     * @return Returns true if this connection already exists.
+     */
     public boolean connectionExists(NodeConnection checkConnection) {
         for(NodeConnection thisConnection : connections)
-            if(checkConnection.equals(thisConnection)) return true; 
+            if(checkConnection.equals(thisConnection)) {
+                Mechano.log("EXISTS? TRUE");
+                return true; 
+            }
+        Mechano.log("EXISTS? FALSE");
         return false;
+    }
+
+    /***
+     * Compares ElectricNodes for equivalence. <p>
+     * Note that "equivalence" in this case does not
+     *  consider some of the more specific data stored
+     * in an ElectricNode, we've opted to only
+     * compare the absolute posiitons of both nodes
+     * for simplicity.
+     * @param other ElectricNode to compare to
+     * @return True if these ElectricNodes are equivalent
+     */
+    public boolean equals(Object other) {
+        if(other != null && other instanceof ElectricNode otherNode)
+            return getPosition().equals(otherNode.getPosition());
+        return false;
+    }
+
+    public int hashCode() {
+        return getPosition().hashCode();
     }
     
     /***
@@ -187,10 +216,15 @@ public class ElectricNode {
      * fails, LINK_ADDED if this connection succeeds.
      */
     public NodeConnectResult addConnection(NodeConnection connection) {
+
+        if(connection == null) throw new NullPointerException("Failure attempting to add NodeConnection - Connection is null!");
+        if(connection.goesNowhere()) throw new IllegalStateException("Failure attempting to add NodeConnection - Connection goes nowhere: -> " + connection);
+
         int firstNullIndex = getFirstNullIndex();
 
-        if(firstNullIndex == -1) return NodeConnectResult.NODE_FULL;
+        if(connection.getSourcePos() == connection.getDestPos()) 
         if(connectionExists(connection)) return NodeConnectResult.LINK_EXISTS;
+        if(firstNullIndex == -1) return NodeConnectResult.NODE_FULL;
 
         connections[firstNullIndex] = connection;
         return NodeConnectResult.LINK_ADDED;
@@ -432,11 +466,15 @@ public class ElectricNode {
     }
 
     public Color getColor() {
-        return mode.getSelected();
+        return getColor(0f);
     }
 
     public Color getColor(float percent) {
         return mode.getColor(percent);
+    }
+
+    public Color getColor(int percent) {
+        return getColor((float) percent);
     }
 
     public NodeMode getMode() {

--- a/src/main/java/com/quattage/mechano/core/electricity/node/base/ElectricNodeBuilder.java
+++ b/src/main/java/com/quattage/mechano/core/electricity/node/base/ElectricNodeBuilder.java
@@ -17,7 +17,7 @@ public class ElectricNodeBuilder {
     private NodeLocation location;
     private String id = null;
     private int maxConnections = 1;
-    private float size = 0.2f;
+    private float size = 4/16f;
 
     public ElectricNodeBuilder(NodeBankBuilder activeBuilder, BlockEntity target) {
         this.activeBuilder = activeBuilder;

--- a/src/main/java/com/quattage/mechano/core/electricity/node/base/NodeMode.java
+++ b/src/main/java/com/quattage/mechano/core/electricity/node/base/NodeMode.java
@@ -13,20 +13,20 @@ import net.minecraft.util.StringRepresentable;
  */
 public enum NodeMode implements StringRepresentable {
     NONE(false, false, new Color(110, 110, 110), new Color(196, 196, 196)),
-    INSERT(true, false, new Color(250, 255, 96), new Color(189, 255, 44)),
-    EXTRACT(false, true, new Color(255, 96, 250), new Color(255, 44, 189)),
-    BOTH(true, true, new Color(96, 250, 255), new Color(44, 189, 255));
+    INSERT(true, false, new Color(241, 0, 149), new Color(255, 101, 196)),
+    EXTRACT(false, true, new Color(149, 241, 0), new Color(196, 255, 101)),
+    BOTH(true, true, new Color(0, 149, 241), new Color(101, 196, 255));
 
     private final boolean isInput;
     private final boolean isOutput;
-    private final Color greyedOut;
-    private final Color selected;
+    private final Color baseColor;
+    private final Color highlightColor;
 
     private NodeMode(boolean isInput, boolean isOutput, Color greyedOut, Color selected) {
         this.isInput = isInput;
         this.isOutput = isOutput;
-        this.selected = selected;
-        this.greyedOut = greyedOut;
+        this.highlightColor = selected;
+        this.baseColor = greyedOut;
     }
 
     public String toString() {
@@ -105,8 +105,16 @@ public enum NodeMode implements StringRepresentable {
      * Gets the highlight color of this node.
      * @return
      */
-    public Color getSelected() {
-        return selected.copy();
+    public Color getHighlightColor() {
+        return highlightColor.copy();
+    }
+
+    /***
+     * Gets the "greyed-out" color of this node.
+     * @return
+     */
+    public Color getBaseColor() {
+        return baseColor.copy();
     }
 
     /***
@@ -115,6 +123,8 @@ public enum NodeMode implements StringRepresentable {
      * @return
      */
     public Color getColor(float percent) {
-        return greyedOut.copy().mixWith(selected, percent);
+        if(percent >= 1) return highlightColor;
+        if(percent <= 0) return baseColor;
+        return baseColor.copy().mixWith(highlightColor, percent);
     }
 }

--- a/src/main/java/com/quattage/mechano/core/electricity/node/connection/NodeConnection.java
+++ b/src/main/java/com/quattage/mechano/core/electricity/node/connection/NodeConnection.java
@@ -166,10 +166,17 @@ public abstract class NodeConnection {
      * @return True if both the source and destination positions the same.
      */
     public boolean equals(Object other) {
-        if(other instanceof NodeConnection c) {
-            Vec3 s = c.getSourcePos();
-            Vec3 d = c.getDestPos();
-            return s == null ? false : d == null ? false : s.equals(d);
+        if(other instanceof NodeConnection otherConnection) {
+            Vec3[] positions = new Vec3[4];
+            positions[0] = this.getSourcePos();
+            positions[1] = this.getDestPos();
+            positions[2] = otherConnection.getSourcePos();
+            positions[3] = otherConnection.getDestPos(); 
+
+            for(Vec3 pos : positions)
+                if(pos == null) return false;
+
+            return positions[0].equals(positions[2]) && positions[1].equals(positions[3]);
         }
         return false;
     }
@@ -185,6 +192,17 @@ public abstract class NodeConnection {
         double distance2 = other.getSourcePos().distanceTo(other.getDestPos());
         
         return Double.compare(distance1, distance2);
+    }
+
+
+    /***
+     * This connection "goes nowhere" if its source and destination positions are the same, or if either
+     * position is null.
+     * @return True if this connection's source and destination positions are equivalent or if either is null.
+     */
+    public boolean goesNowhere() {
+        if(sourcePos == null || destPos == null) return true;
+        return sourcePos.equals(destPos);
     }
 
     /***

--- a/src/main/java/com/quattage/mechano/core/electricity/rendering/ElectricBlockRenderer.java
+++ b/src/main/java/com/quattage/mechano/core/electricity/rendering/ElectricBlockRenderer.java
@@ -36,7 +36,7 @@ public class ElectricBlockRenderer<T extends ElectricBlockEntity> extends SafeBl
     protected void renderSafe(ElectricBlockEntity ebe, float partialTicks, PoseStack local, 
         MultiBufferSource bufferSource, int light, int overlay) {
     
-        ElectricNode[] nodes = ebe.nodes.values();
+        ElectricNode[] nodes = ebe.nodeBank.values();
 
         for(int n = 0; n < nodes.length; n++) {
             ElectricNode thisNode = nodes[n];

--- a/src/main/java/com/quattage/mechano/core/electricity/rendering/ElectricNodeWireDebugger.java
+++ b/src/main/java/com/quattage/mechano/core/electricity/rendering/ElectricNodeWireDebugger.java
@@ -30,13 +30,13 @@ public class ElectricNodeWireDebugger extends ClientBehavior {
             BlockPos lookingBlockPos, double pTicks) {
         
         if(world.getBlockEntity(lookingBlockPos) instanceof ElectricBlockEntity blockEntity) {
-            for(ElectricNode node : blockEntity.nodes.values()) {
+            for(ElectricNode node : blockEntity.nodeBank.values()) {
                 CreateClient.OUTLINER.showAABB(node.getId() + "Highlight", node.getHitbox()
                     .inflate((Math.sin(((pTicks * 0.201) - 10.2) / 6.36) * 0.01)))
                     .disableCull()
                     .lineWidth(1 / 32f)
                     .colored(new Color(255, 255, 255)
-                        .mixWith(node.getColor(), Mth.clamp((float)Math.sin((pTicks - 0.50) * 3.2) * 0.4f + 1, 0, 1)));
+                        .mixWith(node.getColor(1f), Mth.clamp((float)Math.sin((pTicks - 0.50) * 3.2) * 0.4f + 1, 0, 1)));
             }
         }
     }

--- a/src/main/java/com/quattage/mechano/core/events/ClientBehavior.java
+++ b/src/main/java/com/quattage/mechano/core/events/ClientBehavior.java
@@ -52,11 +52,19 @@ public abstract class ClientBehavior {
     @OnlyIn(Dist.CLIENT)
 	public void tick() {
         updateValues();
-		if (player == null || world == null || !(instance.hitResult instanceof BlockHitResult hit))
+		if (player == null || world == null || !(instance.hitResult instanceof BlockHitResult raycast))
 			return;
 
-        this.hit = hit.getLocation();
-        BlockPos hitBlockPos = hit.getBlockPos();
+        this.hit = raycast.getLocation();
+
+        /** DEBUG SHIT */
+
+        //NodeBank.findAlongRay(instance.cameraEntity.getEyePosition(), raycast.getLocation());
+
+        /** END OF DEBUG SHIT */
+
+
+        BlockPos hitBlockPos = raycast.getBlockPos();
 
         if(!shouldTick(world, player, mainHandStack, offHandStack, this.hit, hitBlockPos)) return;
         

--- a/src/main/java/com/quattage/mechano/core/util/VectorHelper.java
+++ b/src/main/java/com/quattage/mechano/core/util/VectorHelper.java
@@ -2,21 +2,39 @@ package com.quattage.mechano.core.util;
 
 import org.joml.Vector3f;
 
+import com.quattage.mechano.Mechano;
+import com.simibubi.create.AllSpecialTextures;
+import com.simibubi.create.CreateClient;
+import com.simibubi.create.foundation.utility.Color;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Vec3i;
 import net.minecraft.util.Mth;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.HitResult;
 import net.minecraft.world.phys.Vec3;
 
 public class VectorHelper {
 
+    /***
+     * Converts a Vec3 to a Vec3i
+     */
     public static Vec3i round(Vec3 vec) {
         return new Vec3i((int)vec.x, (int)vec.y, (int)vec.z);
     }
 
+    /***
+     * Converts a Vector3f to a Vec3
+     */
     public static Vec3 toVec(Vector3f vec) {
         return new Vec3(vec);
     }
 
+    /***
+     * Converts a BlockPos to a Vec3
+     */
     public static Vec3 toVec(BlockPos pos) {
         return new Vec3(pos.getX(), pos.getY(), pos.getZ());
     }
@@ -29,14 +47,114 @@ public class VectorHelper {
         root.set((p0.x() - p1.x()) + m, (p0.y() - p1.y()), (p0.z() - p1.z()) + m);
     }
 
+    /***
+     * Draws a simple debug box at the given Vec3 position
+     */
+    public static void drawDebugBox(Vec3 pos) {
+        drawDebugBox(pos, toColor(pos), "debug_" + pos.hashCode());
+    }
+
+    /***
+     * Draws a simple debug box at the given Vec3 position
+     */
+    public static void drawDebugBox(Vec3 pos, String hash) {
+        drawDebugBox(pos, toColor(pos), hash);
+    }
+    
+    /***
+     * Draws a simple debug box at the given Vec3 position
+     */
+    public static void drawDebugBox(Vec3 pos, Color color) {
+        drawDebugBox(pos, color, "debug_" + pos.hashCode());
+    }
+
+    /***
+     * Draws a simple debug box at the given Vec3 position
+     */
+    public static void drawDebugBox(Vec3 pos, Color color, String hash) {
+        CreateClient.OUTLINER.showAABB(hash, VectorHelper.toAABB(pos, 0.2f))
+            .disableLineNormals()
+            .withFaceTexture(AllSpecialTextures.CUTOUT_CHECKERED)
+            .lineWidth(0.06f)
+            .colored(color);
+    }
+
+    /***
+     * Creates a new AABB at the given Vec3.
+     * @param pos Vec3 to use as a basis
+     * @param s Size of the AABB
+     * @return A new AABB at the given Vec3
+     */
+    public static AABB toAABB(Vec3 pos, float s) {
+        Vec3 size = new Vec3(s, s, s);
+        return new AABB(pos.subtract(size), pos.add(size));
+    }
+
+    
+    /***
+     * Creates a new AABB at the given BlockPos.
+     * @param pos BlockPos to use as a basis
+     * @param s Size of the AABB
+     * @return A new AABB at the given BlockPos
+     */
+    public static AABB toAABB(BlockPos pos, float s) {
+        return toAABB(new Vec3(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5) , s);
+    }
+
+    /***
+     * Converts an arbitrary Vec3 (non-normalized) into a percentage based color.
+     * @param vec Vector 
+     * @param variation (Optional, default is 8) Lower numbers result in more noticable 
+     * changes in color, requiring smaller changes to the input vector
+     * @return A new Color derived from the input vector
+     */
+    public static Color toColor(Vec3 vec) {
+        return toColor(vec, 8);
+    }
+
+    /***
+     * Converts an arbitrary Vec3 (non-normalized) into a percentage based color.
+     * @param vec Vector 
+     * @param variation (Optional, default is 8) Lower numbers result in more noticable 
+     * changes in color, requiring smaller changes to the input vector
+     * @return A new Color derived from the input vector
+     */
+    public static Color toColor(Vec3 vec, int variation) {
+        if(variation < 2) variation = 2;
+
+        Vec3i norm = new Vec3i(
+            (int)Math.abs(vec.x % variation),
+            (int)Math.abs(vec.y % variation),
+            (int)Math.abs(vec.z % variation)
+        );
+
+        Color out = new Color(
+            (int)((norm.getX() / 8f) * 255),
+            (int)((norm.getY() / 8f) * 255),
+            (int)((norm.getZ() / 8f) * 255)
+        );
+
+        return out;
+    }
+
+    /***
+     * Casts coordinates of a Vec3 to ints and returns a BlockPos
+     * @param vec Vector to cast
+     * @return A converted BlockPos
+     */
     public static BlockPos toBlockPos(Vec3 vec) {
         return new BlockPos(
-            (int)vec.x, 
-            (int)vec.y, 
-            (int)vec.z
+            (int)Math.floor(vec.x), 
+            (int)Math.floor(vec.y), 
+            (int)Math.floor(vec.z)
         );
     }
 
+    /***
+     * Casts coordinates of a Vec3 to ints and returns a BlockPos
+     * @param vec Vector to cast
+     * @return A converted BlockPos
+     */
     public static BlockPos toBlockPos(Vector3f vec) {
         return new BlockPos(
             (int)vec.x, 
@@ -53,20 +171,32 @@ public class VectorHelper {
         return Math.sinh((2 * x + 2 * p1 - d) / (2 * a));
     }
 
+    /***
+     * fairy dust magic wizard gnome code, brought to you buy ConnectableChains
+     */
     public static double drip2(double a, double x, double d, double h) {
         double p1 = a * aSinh((h / (2d * a)) * (1d / Math.sinh(d / (2d * a))));
         double p2 = -a * Math.cosh((2d * p1 - d) / (2d * a));
         return p2 + a * Math.cosh((((2d * x) + (2d * p1)) - d) / (2d * a));
     }
 
+    /***
+     * fairy dust magic wizard gnome code, brought to you buy ConnectableChains
+     */
     public static double drip2prime(double x, double d, double h) {
         return drip2prime(1, x, d, h);
     }
 
+    /***
+     * fairy dust magic wizard gnome code, brought to you buy ConnectableChains
+     */
     public static double drip2(double x, double d, double h) {
         return drip2(1, x, d, h);
     }
 
+    /***
+     * fairy dust magic wizard gnome code, brought to you buy ConnectableChains
+     */
     private static double aSinh(double r) {
         return Math.log(r + Math.sqrt(r * r + 1.0));
     }
@@ -89,10 +219,6 @@ public class VectorHelper {
         return fT > tF ? fT : tF;
     }
 
-    public static float distanceBetween(Vector3f vec1, Vector3f vec2) {
-        return (float)new Vec3(vec1).distanceTo(new Vec3(vec2));
-    }
-
     public static float getLength(Vector3f vec) {
         return (float)Math.sqrt(Math.fma(vec.x(), vec.x(), Math.fma(vec.y(), vec.y(), vec.z() * vec.z())));
     }
@@ -101,12 +227,45 @@ public class VectorHelper {
         return (float)(s / Math.sqrt(1 + k * k));
     }
 
-    public static Vector3f normalizeToLength(Vector3f vec, float length) {
-        float scalar = (float)(Mth.fastInvSqrt(Math.fma(vec.x(), vec.x(), Math.fma(vec.y(), vec.y(), vec.z() * vec.z()))) * length);
+    /***
+     * Identical to Vec3.normalize() in principal, but 
+     * with slightly more control when needed.
+     * @param vec Vector to normalize
+     * @param magnitude Magnitude to normalize to
+     * @return a normalized Vector3f.
+     */
+    public static Vector3f normalizeToLength(Vector3f vec, float magnitude) {
+        float scalar = (float)(Mth.fastInvSqrt(Math.fma(vec.x(), vec.x(), Math.fma(vec.y(), vec.y(), vec.z() * vec.z()))) * magnitude);
         return new Vector3f(
             vec.x() * scalar,
             vec.y() * scalar,
             vec.z() * scalar
         );     
+    }
+
+    /***
+     * A sloppy distance calculator that just converts Vector3fs
+     * to Vec3s before calculating distance. Don't use this.
+     */
+    public static float distanceBetween(Vector3f vec1, Vector3f vec2) {
+        return (float)new Vec3(vec1).distanceTo(new Vec3(vec2));
+        // TODO don't be lazy
+    }
+
+    /***
+     * Gets the HitResult for the given player.
+     * @param player 
+     * @return HitResult describing the player's absolute look position.
+     */
+    public static HitResult getLookingPos(Player player) {
+        Vec3 viewDir = player.getViewVector(1f);
+        float dist = 20;
+
+        Vec3 start = player.getEyePosition(1f);
+        Vec3 end = start.add(viewDir.x * dist, viewDir.y * dist, viewDir.z * dist);
+
+        return player.getCommandSenderWorld().clip(
+            new ClipContext(start, end, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, player)
+        );
     }
 }


### PR DESCRIPTION
- RootUpgradableBlock moved out of its own package
- Some minor field renames
- Size and color of ElectricNode indicators has been increased
- More robust equals() for NodeConnections with better nullchecks
- NodeBank hitfactor increased to 4
- New helper methods in VectorHelper for drawing debug boxes and deriving a color value from an arbitrary Vec3
- NodeBank getClosest() now deals with distance automatically
- New NodeBank findBanksAlongRay() method can search within a designated area for valid NodeBanks and retrieve them
- Lite version of findBanksAlongRay() (findClosestNodeAlongRay()) exists for when the client doesn't need deep access to the entire NodeBank for optimization purposes
- New ElectricNode interactions system allows for locating NodeBanks within the player's frustum, which provides a lot of opportunities for future improvements
- ElectricNodes can now be accessed by the player without having to be looking directly at the parent block's collider